### PR TITLE
Add pre-install time sync check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Usage: collectd-install [ <api_token> ] [ --beta | --test ] [ -H <hostname> ] [ 
  --test will use the test repos instead of release.
  --configure-only will use the installed collectd instead of attempting to install and will not install anything new.
  --insecure will use the insecure -k with any curl fetches.
+ --skip-time-sync-check will skip check for whether the system time is synchronized.
  -h this page.
  ```
- 
+
  ##### Note: Uninstalling from Mac OS X systems
 
  When the install script installs the SignalFx collectd agent on a Mac OS X system, an `uninstall.sh` script is laid down in the directory `/usr/local/share/collectd`. Run this script with administrative privileges to remove collectd and all related configuration from the host. Run the script with `–help` option for detailed instructions, including how to perform a dry run and keep configuration in place after uninstalling.


### PR DESCRIPTION
This adds a pre-install check to see how far apart the system clock is against
pool.ntp.org if ntpdate is available. Otherwise it falls back to checking time
against ingest.signalfx.com with curl. A new flag has been added to skip this
and any future pre-install checks (--skip-checks). If time is out of sync by
more than 10 seconds we abort the install.