### PR TITLE
Hook up Stdin to apt-get Properly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -521,7 +521,7 @@ install_debian_collectd_procedure() {
 
     #Installing signalfx collectd package and plugins
     printf "Installing collectd and additional plugins\n"
-    $sudo apt-get -y install collectd collectd-core
+    $sudo apt-get -y install collectd collectd-core < /dev/tty
 
     #Configuring collectd with basic configuration
 }


### PR DESCRIPTION
If apt-get/dpkg throws up any prompts to the user (e.g. asking to overwrite
existing collectd config files), the user was previously unable to answer since
standard input was not propertly directed to the forked apt-get process
(probably due to how we are piping stdin from curl originally).  This forces
stdin to the controlling tty terminal of the bash script.